### PR TITLE
Fix and extend service tests

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,8 @@ srv:
       bin/bundle exec rake db:reset;
       bundle exec unicorn -c config/unicorn.rb
   environment:
+    ACTIVE_JOB_ADAPTER: inline
+    ACTIVE_JOB_QUEUE_PREFIX: inline
     AUTHENTICATION_REDIRECT_URI: 1
     AUTHENTICATION_SITE_URL: http://auth:45454
     DB_NAME: defence_request_service
@@ -33,6 +35,8 @@ srv:
     AUTHENTICATION_APPLICATION_ID: FA11FA11FA11FA11FA14
     AUTHENTICATION_APPLICATION_SECRET: FA11FA11FA11FA11FA15
 
+    AWS_S3_ASSET_BUCKET_NAME: unused
+    AWS_REGION: unused
     RAILS_SERVE_STATIC_FILES: 1
     FORCE_SSL: false
   ports:
@@ -50,6 +54,8 @@ auth:
       bin/bundle exec rake db:reset;
       bundle exec unicorn -c config/unicorn.rb
   environment:
+    ACTIVE_JOB_ADAPTER: inline
+    ACTIVE_JOB_QUEUE_PREFIX: inline
     DB_NAME: defence_request_service_auth
     FOREMAN: 1
     ROTA_REDIRECT_URI: http://rota:34343/auth/defence_request/callback
@@ -74,6 +80,8 @@ auth:
     SANDBOX_EMAIL: true
     SANDBOX_EMAIL_ADDRESS: iamadefencesolicitor@gmail.com
 
+    AWS_S3_ASSET_BUCKET_NAME: unused
+    AWS_REGION: unused
     RAILS_SERVE_STATIC_FILES: 1
     FORCE_SSL: false
     FORCE_SSL_IN_REDIRECT_URI: false
@@ -92,6 +100,8 @@ rota:
       bin/bundle exec rake db:reset;
       bundle exec unicorn -c config/unicorn.rb
   environment:
+   ACTIVE_JOB_ADAPTER: inline
+   ACTIVE_JOB_QUEUE_PREFIX: inline
    AUTHENTICATION_REDIRECT_URI: 1
    AUTHENTICATION_SITE_URL: http://auth:45454
    DB_NAME: defence_request_service_rota
@@ -105,6 +115,8 @@ rota:
    AUTHENTICATION_APPLICATION_ID: FA11FA11FA11FA11FA12
    AUTHENTICATION_APPLICATION_SECRET: FA11FA11FA11FA11FA13
 
+   AWS_S3_ASSET_BUCKET_NAME: unused
+   AWS_REGION: unused
    RAILS_SERVE_STATIC_FILES: 1
    FORCE_SSL: false
 

--- a/spec/02_create_request_spec.rb
+++ b/spec/02_create_request_spec.rb
@@ -1,0 +1,48 @@
+require 'spec_helper'
+
+RSpec.describe "Creating Defence Request" do
+  specify "CSO creates a new Defence Request" do
+    visit SERVICE_APP_URI
+
+    click_link "New request"
+
+    within ".detainee" do
+      fill_in "Name", with: "Mannie Badder"
+      choose "Male"
+      fill_in "defence_request_date_of_birth_year", with: "1976"
+      fill_in "defence_request_date_of_birth_month", with: "01"
+      fill_in "defence_request_date_of_birth_day", with: "01"
+      fill_in "defence_request_detainee_address",
+        with: "House of the rising sun, Letsby Avenue, Right up my street, London, Greater London, XX1 1XX"
+      choose "defence_request_appropriate_adult_false"
+      choose "defence_request_interpreter_required_false"
+    end
+
+    within ".case-details" do
+      fill_in "defence_request_investigating_officer_name", with: "Dave Mc.Copper"
+      fill_in "defence_request_investigating_officer_contact_number", with: "0207 111 0000"
+      fill_in "Custody number", with: "AN14574637587"
+      fill_in "Offences", with: "BadMurder"
+      fill_in "defence_request_circumstances_of_arrest", with: "He looked a bit shady"
+      choose "defence_request_fit_for_interview_true"
+      fill_in "defence_request_time_of_arrest_date", with: "02 Feb 2002"
+      fill_in "defence_request_time_of_arrest_hour", with: "02"
+      fill_in "defence_request_time_of_arrest_min", with: "02"
+      fill_in "defence_request_time_of_arrival_date", with: "01 Jan 2001"
+      fill_in "defence_request_time_of_arrival_hour", with: "01"
+      fill_in "defence_request_time_of_arrival_min", with: "01"
+      fill_in "defence_request_time_of_detention_authorised_date", with: "03 Mar 2003"
+      fill_in "defence_request_time_of_detention_authorised_hour", with: "03"
+      fill_in "defence_request_time_of_detention_authorised_min", with: "03"
+    end
+
+    click_button "Create request"
+
+    click_button "Submit request"
+
+    expect(page.current_url).to eql("#{SERVICE_APP_URI}/dashboard")
+
+    expect(page).to have_css(".name", text: "Mannie Badder")
+    expect(page).to have_css(".state", text: "Submitted")
+  end
+end

--- a/spec/02_create_request_spec.rb
+++ b/spec/02_create_request_spec.rb
@@ -2,8 +2,17 @@ require 'spec_helper'
 
 RSpec.describe "Creating Defence Request" do
   specify "CSO creates a new Defence Request" do
-    visit SERVICE_APP_URI
+    given_cso_is_in_the_service_app
+    when_they_create_and_submit_new_request
+    then_they_are_on_the_dashboard
+    and_they_can_see_the_new_request_in_the_list
+  end
 
+  def given_cso_is_in_the_service_app
+    visit SERVICE_APP_URI
+  end
+
+  def when_they_create_and_submit_new_request
     click_link "New request"
 
     within ".detainee" do
@@ -39,10 +48,15 @@ RSpec.describe "Creating Defence Request" do
     click_button "Create request"
 
     click_button "Submit request"
+  end
 
+  def then_they_are_on_the_dashboard
     expect(page.current_url).to eql("#{SERVICE_APP_URI}/dashboard")
+  end
 
+  def and_they_can_see_the_new_request_in_the_list
     expect(page).to have_css(".name", text: "Mannie Badder")
     expect(page).to have_css(".state", text: "Submitted")
   end
+
 end

--- a/spec/99_unauthenticate_spec.rb
+++ b/spec/99_unauthenticate_spec.rb
@@ -7,6 +7,6 @@ RSpec.describe "Unauthenticate" do
     click_link("Sign out")
 
     we_get_redirected_to_the_auth_app
-    expect(page).to have_content("You need to sign in or sign up before continuing.")
+    expect(page).to have_content("Signed out successfully")
   end
 end


### PR DESCRIPTION
This PR: 
- Adds missing ENVs to make the tests run again
- Adds new tests to create a defence request by CSO

There are some problems with Browserstack and IE. I'll fix them, but for the moment this works well for running locally.
